### PR TITLE
Update McKathlin_GameOver.js plugindesc to include MZ

### DIFF
--- a/McKathlin_GameOver.js
+++ b/McKathlin_GameOver.js
@@ -36,7 +36,7 @@ McKathlin.GameOver = McKathlin.GameOver || {};
 
 /*:
  * @target MZ
- * @plugindesc v1.3.1 Change what happens when the party dies or Game Over is called.
+ * @plugindesc MZ v1.3.1 Change what happens when the party dies or Game Over is called.
  * @author McKathlin
  * @url https://www.tyruswoo.com
  * 


### PR DESCRIPTION
Since we make MV and MZ plugins, each plugin should state what version it is at the beginning of the plugindesc line. This change brings us into line with that standard.